### PR TITLE
Pretty names

### DIFF
--- a/cavedb/__init__.py
+++ b/cavedb/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'cavedb.apps.CaveDBConfig'
+default_app_config = 'cavedb.apps.CaveDBConfig'  # pylint: disable=C0103

--- a/cavedb/__init__.py
+++ b/cavedb/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'cavedb.apps.CaveDBConfig'

--- a/cavedb/apps.py
+++ b/cavedb/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CaveDBConfig(AppConfig):
+    name = 'cavedb'
+    verbose_name = 'Cave Database'

--- a/cavedb/models.py
+++ b/cavedb/models.py
@@ -750,6 +750,8 @@ class Feature(models.Model):
         return '%s (%s)' % (self.name, self.survey_id)
 
     class Meta:
+        verbose_name = 'Cave or Karst Feature'
+        verbose_name_plural = 'Caves and Karst Features'
         ordering = ["name"]
 
 


### PR DESCRIPTION
Cosmetic changes to Django Admin panel:

- Display the `cavedb` app name as "Cave Database" rather than "Cavedb"

- Display "Caves and Karst Features", "Select Cave or Karst Feature to change", "Add Cave or Karst Feature" for the `Feature` model.